### PR TITLE
Make the sign-up email confirmation process more clear

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -38,26 +38,26 @@ module AccountsHelper
     when Person::STATUS_REVIEW
       explanation = "<p>Your account is pending review. #{link_to('Learn more about account reviews',accounts_review_path)}</p>"
     when Person::STATUS_SIGNUP
-      explanation = "<p>You need to confirm your email address. #{link_to('Learn more about email confirmation',accounts_pending_confirmation_path)}</p>"
+      explanation = "<h4>You need to confirm your email address.</h4> <p>#{link_to('Learn how',accounts_pending_confirmation_path, class: 'btn btn-default btn-primary')}</p>"
     when Person::STATUS_CONFIRM_EMAIL
       explanation = "<p>You need to confirm your email address. #{link_to('Learn more about email confirmation',accounts_pending_confirmation_path)}</p>"
     when Person::STATUS_RETIRED
       explanation = "<p>Your account has been retired. #{link_to('Contact us for more information.',help_path)}</p>"
     when Person::STATUS_INVALIDEMAIL
       explanation = "<p>Your email is invalid. #{link_to('Learn more about email confirmation',accounts_pending_confirmation_path)}</p>"
-    when Person::STATUS_CONTRIBUTOR 
+    when Person::STATUS_CONTRIBUTOR
       # just for debugging - should never see in normal operation
-      explanation = "<p>Your current account status is: <span class='label label-info'>Person</span></p>"     
+      explanation = "<p>Your current account status is: <span class='label label-info'>Person</span></p>"
     when Person::STATUS_REVIEWAGREEMENT
-      # just for debugging - should never see in normal operation 
-      explanation = "<p>Your current account status is: <span class='label label-info'>Pending Agreement Review</span></p>"     
+      # just for debugging - should never see in normal operation
+      explanation = "<p>Your current account status is: <span class='label label-info'>Pending Agreement Review</span></p>"
      when Person::STATUS_PARTICIPANT
       # just for debugging - should never see in normal operation
-      explanation = "<p>Your current account status is: <span class='label label-info'>Participant</span></p>"          
+      explanation = "<p>Your current account status is: <span class='label label-info'>Participant</span></p>"
     else
       explanation = "<p>Unknown account status.</p>"
     end
     return explanation.html_safe
   end
-  
+
 end

--- a/app/views/accounts/post_signup.html.erb
+++ b/app/views/accounts/post_signup.html.erb
@@ -8,19 +8,16 @@
         <h1>Thanks for signing up!</h1>
 
         <div class="alert alert-info">
-        <h3>Please check your email and confirm your address</h3>
-        <p>We just sent an email to: <strong class="mono"><%= current_person.email %></strong> (<%= link_to('edit', edit_person_path(current_person))%>).</p>
-        <p>Please follow the instructions to confirm your email address.</p>
+          <h3>Please check your email and confirm your address</h3>
+          <p>We just sent an email to: <strong class="mono"><%= current_person.email %></strong> (<%= link_to('edit', edit_person_path(current_person))%>).</p>
+          <br />
+          <p>Please follow the instructions to confirm your email address.</p>
       </div>
       </div>
     </div>
 
     <div class="row">
-      <div class="col-md-6">
-        <%= render(:partial => 'email_help_notice') %>
-      </div>
-
-      <div class="col-md-6">
+      <div class="col-md-12">
         <h4>While you are waiting...</h4>
         <p><%= link_to('View your Profile',person_path(current_person), class: 'btn btn-default btn-lg') -%></p>
       </div>

--- a/app/views/home/pending.html.erb
+++ b/app/views/home/pending.html.erb
@@ -1,10 +1,14 @@
 <%- @page_title = "eXtension - On Hold" -%>
 
 <div class="row">
-  <div class="col-md-12">
-    <h2>Your account is on hold</h2>
-    <%= explain_pending_status(current_person.account_status) %>
+  <div class="col-md-10 col-md-offset-1">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="alert alert-info">
+          <h2>Your account is on hold</h2>
+          <%= explain_pending_status(current_person.account_status) %>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
-
-


### PR DESCRIPTION
* remove "I didn't receive the email" help text from the Thanks for Signing Up screen because we need to person to go check their email first before we offer solutions.
* Provide a link to their Profile as a secondary action
* Make the Email Confirmation Pending banner more obvious