### PR TITLE
clean up email aliases on account delete

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -84,7 +84,7 @@ class Person < ActiveRecord::Base
                                    community_connections.sendnotifications as sendnotifications,
                                    communities.*"
 
-  has_many :email_aliases, as: :aliasable
+  has_many :email_aliases, as: :aliasable, dependent: :destroy
   has_one :google_account, dependent: :destroy
   has_one :share_account, dependent: :destroy
   belongs_to :primary_account, class_name: 'Person'


### PR DESCRIPTION
Unconfirmed accounts are trashed, but the email aliases aren't dropped.