### PR TITLE
hide editing markup from unauthenticated views

### DIFF
--- a/app/views/communities/gallery.html.erb
+++ b/app/views/communities/gallery.html.erb
@@ -11,20 +11,20 @@
     <div class="text-right">
       <p class="btn btn-default btn-xs" data-toggle="modal" data-target="#myModal">change community masthead</p>
     </div>
-  <%- end -%>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog modal-lg" role="document">
-      <div class="modal-content">
-        <div class="modal-body">
-          <%= render(:partial => 'community_masthead_form', :locals => {community: @community}) %>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+    <!-- Modal -->
+    <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+      <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+          <div class="modal-body">
+            <%= render(:partial => 'community_masthead_form', :locals => {community: @community}) %>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  <%- end -%>
 
 
   <p class="community-public-description"><%= description_for_community(@community) -%></p>


### PR DESCRIPTION
Namely, don't display image specs under the gallery image resulting in FB sucking those in as a caption