### PR TITLE
Fix email forward issue

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -37,7 +37,7 @@ class AccountsController < ApplicationController
       return redirect_to(signin_url)
     end
 
-    if(@signup_email.email =~ /extension\.org$/i)
+    if(@signup_email.email =~ /@extension\.org$/i)
       @signup_email.errors.add(:email, "For technical reasons, signing up with an eXtension.org email address is not possible.".html_safe)
       return render(:action => "signup")
     end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -89,7 +89,7 @@ class PeopleController < ApplicationController
     # prevent setting email to @extension.org unless it already is @extension.org
     if(update_params[:email])
       if(update_params[:email] =~ /extension\.org$/i)
-        if(@person.email =~ /extension\.org$/i)
+        if(@person.email =~ /@extension\.org$/i)
           if(@person.email.downcase != update_params[:email].strip.downcase)
             @person.attributes = update_params
             @person.errors.add(:email, "For technical reasons, changing to a different extension.org email address is not possible.".html_safe)

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -218,6 +218,12 @@ class PeopleController < ApplicationController
         return render
       end
 
+
+      if(@invitation.email =~ /@extension\.org$/i)
+        @invitation.errors.add(:email, "For technical reasons, inviting an eXtension.org email address is not possible.".html_safe)
+        return render
+      end
+
       @invitation.person = current_person
       if(@invitation.save)
         @signup_email.update_attribute(:invitation_id, @invitation.id) if(@signup_email)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -563,7 +563,7 @@ class Person < ActiveRecord::Base
       "#{self.primary_account.idstring}@extension.org"
     elsif(self.google_apps_email?)
       "#{self.idstring}@apps.extension.org"
-    elsif(self.email =~ /extension\.org$/i)
+    elsif(self.email =~ /@extension\.org$/i)
       EmailAlias::NOWHERE_LOCATION
     else
       self.email
@@ -579,7 +579,7 @@ class Person < ActiveRecord::Base
   end
 
   def display_email_is_extension?
-    (!(self.display_email =~ /extension\.org$/i).nil?)
+    (!(self.display_email =~ /@extension\.org$/i).nil?)
   end
 
   def all_email_aliases


### PR DESCRIPTION
Fixes #185 

Wherein "northeastextension.org" was matching /extension.org 

s//"sigh"/g